### PR TITLE
feat(admin): add setting to add scripts in admin

### DIFF
--- a/src/Form/Type/Settings/ScriptsType.php
+++ b/src/Form/Type/Settings/ScriptsType.php
@@ -62,5 +62,17 @@ class ScriptsType extends AbstractSettingsType implements SettingsTypeInterface
                 'help_html' => true,
             ]
         );
+
+        if ($this->isDefaultForm($builder)) {
+            $this->addWithDefaultCheckbox(
+                $builder,
+                'admin_javascripts',
+                TextareaType::class,
+                [
+                    'label' => 'monsieurbiz_scripts.form.admin_javascripts',
+                    'required' => false,
+                ]
+            );
+        }
     }
 }

--- a/src/Resources/config/monsieurbiz/settings.yaml
+++ b/src/Resources/config/monsieurbiz/settings.yaml
@@ -22,3 +22,5 @@ monsieurbiz_sylius_settings:
                         console.log('Order amount : %%orderAmount%%');
                         console.log('Order currency : %%orderCurrency%%');
                     </script>
+                admin_javascripts: |
+                    <script type="text/javascript">console.log('Admin javascripts settings');</script>

--- a/src/Resources/config/sylius/ui.yaml
+++ b/src/Resources/config/sylius/ui.yaml
@@ -20,3 +20,8 @@ sylius_ui:
                 monsieurbiz_scripts_checkout_success:
                     template: "@MonsieurBizSyliusScriptsPlugin/Shop/Scripts/_checkoutSuccess.html.twig"
                     priority: 9999
+        sylius.admin.layout.javascripts:
+            blocks:
+                monsieurbiz_scripts_admin_javascripts:
+                    template: "@MonsieurBizSyliusScriptsPlugin/Admin/Scripts/_javascripts.html.twig"
+                    priority: 9999

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -14,6 +14,7 @@ monsieurbiz_scripts:
                         <li>Order currency : %orderCurrency%</li>
                     </ul>
             </div>
+        admin_javascripts: 'Script on the administration pages'
     settings:
         scripts:
             plugin_name: Scripts

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -14,6 +14,7 @@ monsieurbiz_scripts:
                         <li>Devise de la commande : %orderCurrency%:</li>
                     </ul>
             </div>
+        admin_javascripts: 'Script sur les pages d''administration'
     settings:
         scripts:
             plugin_name: Scripts

--- a/src/Resources/views/Admin/Scripts/_javascripts.html.twig
+++ b/src/Resources/views/Admin/Scripts/_javascripts.html.twig
@@ -1,0 +1,1 @@
+{{ setting('monsieurbiz_scripts.scripts', 'admin_javascripts')|raw }}


### PR DESCRIPTION
## Add settings for admin javascripts

![image](https://github.com/user-attachments/assets/b4bd3b81-806c-4988-869c-149996b09f0b)

## Sylius UI Event

Plugged on `sylius.admin.layout.javascripts` event

## Sample JS

![image](https://github.com/user-attachments/assets/01d530fe-810e-4a88-b26e-33cdf8e59df0)
